### PR TITLE
Add support for the TBB backend, and optimise the CPU versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-TARGETS = naive cuda cupla-cuda cupla-serial
+TARGETS = naive cuda cupla-cuda cupla-serial cupla-tbb
 
-.PHONY: default all debug clean $(TARGETS)
+.PHONY: all debug clean $(TARGETS)
 
 CXX := g++-7
 CXX_FLAGS := -O2 -std=c++14 -ftemplate-depth-512
@@ -13,8 +13,6 @@ NVCC_DEBUG := -g -lineinfo
 ALPAKA_BASE := $(HOME)/src/alpaka/alpaka
 CUPLA_BASE  := $(HOME)/src/alpaka/cupla
 CUPLA_FLAGS := -DALPAKA_DEBUG=0 -DCUPLA_STREAM_ASYNC_ENABLED=1 -I$(ALPAKA_BASE)/include -I$(CUPLA_BASE)/include -L$(CUPLA_BASE)/lib
-
-default: naive
 
 all: $(TARGETS)
 
@@ -50,7 +48,7 @@ main-cupla-cuda: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
 debug-cupla-cuda: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
 	$(NVCC) -x cu -w $(NVCC_FLAGS) -DDIGI_CUPLA -DALPAKA_ACC_GPU_CUDA_ENABLED $(CUPLA_FLAGS) -lcupla-cuda $(NVCC_DEBUG) -o debug-cupla-cuda main.cc rawtodigi_cupla.cc
 
-# Alpaka/cupla implementation, with serial cpu backend
+# Alpaka/cupla implementation, with serial backend
 cupla-serial: main-cupla-serial
 
 main-cupla-serial: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
@@ -58,3 +56,12 @@ main-cupla-serial: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
 
 debug-cupla-serial: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
 	$(CXX) $(CXX_FLAGS) -DDIGI_CUPLA -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(CUPLA_FLAGS) -pthread $(CXX_DEBUG) -o debug-cupla-serial main.cc rawtodigi_cupla.cc -lcupla-serial
+
+# Alpaka/cupla implementation, with TBB backend
+cupla-tbb: main-cupla-tbb
+
+main-cupla-tbb: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
+	$(CXX) $(CXX_FLAGS) -DDIGI_CUPLA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(CUPLA_FLAGS) -pthread -o main-cupla-tbb main.cc rawtodigi_cupla.cc -lcupla-tbb -ltbb -lrt
+
+debug-cupla-tbb: main.cc rawtodigi_cupla.cc rawtodigi_cupla.h
+	$(CXX) $(CXX_FLAGS) -DDIGI_CUPLA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(CUPLA_FLAGS) -pthread $(CXX_DEBUG) -o debug-cupla-tbb main.cc rawtodigi_cupla.cc -lcupla-tbb -ltbb -lrt

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ The purpose of this test program is to experiment with various
 
 ## Current implementations
 
-| Implementation | Executable           | `make` target | `#ifdef` macro |
-|----------------|----------------------|---------------|----------------|
-| Naive CPU      | `main-naive`         |`naive`        | `DIGI_NAIVE`   |
-| CUDA           | `main-cuda`          |`cuda`         | `DIGI_CUDA`    |
-| Cupla on CPU   | `main-cupla-serial`  |`cupla-serial` | `DIGI_CUPLA`   |
-| Cupla on GPU   | `main-cupla-cuda`    |`cupla-cuda`   | `DIGI_CUPLA`   |
+| Implementation | Executable           | `make` target | `#ifdef` macros                                    |
+|----------------|----------------------|---------------|----------------------------------------------------|
+| Naive CPU      | `main-naive`         |`naive`        | `DIGI_NAIVE`                                       |
+| CUDA           | `main-cuda`          |`cuda`         | `DIGI_CUDA`                                        |
+| Cupla on CPU   | `main-cupla-serial`  |`cupla-serial` | `DIGI_CUPLA`, `ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED` |
+| Cupla on CPU   | `main-cupla-tbb`     |`cupla-tbb`    | `DIGI_CUPLA`, `ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED` |
+| Cupla on GPU   | `main-cupla-cuda`    |`cupla-cuda`   | `DIGI_CUPLA`, `ALPAKA_ACC_GPU_CUDA_ENABLED`        |
 
 ### Naive CPU
 
@@ -25,32 +26,48 @@ GPU.
 ### Cupla
 
 The Cupla test program can be compiled for different backends; so far it has
-been tested with the CUDA backend (`-DALPAKA_ACC_GPU_CUDA_ENABLED`) and the
-serial CPU backend (`-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED`). The CUDA backend
-requires CUDA 9.2 or CUDA 10.0, and has been tested with gcc 8.
+been tested with the CUDA, serial, and TBB backends.
+The CUDA backend requires CUDA 9.2 or 10.0, and has been tested with gcc 7.
+The TBB backend requires a small patch tu Cupla itself (see [`cupla.patch`]).
 
-In fact, the Cupla libraries need to be built before they can be used:
+Rather than using the advertised `CMake`-based approach, one can build a shared
+library for each Cupla backend, and link it directly with the target program:
 ```bash
+export CUDA_ROOT=/usr/local/cuda
 export ALPAKA_ROOT=$HOME/src/alpaka/alpaka
 export CUPLA_ROOT=$HOME/src/alpaka/cupla
 
 git clone git@github.com:ComputationalRadiationPhysics/alpaka.git -b 0.3.5 $ALPAKA_ROOT
 git clone git@github.com:ComputationalRadiationPhysics/cupla.git  -b 0.1.1 $CUPLA_ROOT
+( cd $CUPLA_ROOT; patch -p1 ) < cupla.patch
 
-mkdir -p $CUPLA_ROOT/build $CUPLA_ROOT/lib
-cd $CUPLA_ROOT/build
+mkdir -p $CUPLA_ROOT/lib
 FILES="$CUPLA_ROOT/src/*.cpp $CUPLA_ROOT/src/manager/*.cpp"
 
-for FILE in $FILES; do
-  $NVCC -DALPAKA_ACC_GPU_CUDA_ENABLED $NVCC_FLAGS -x cu -c $FILE -o cuda_$(basename $FILE).o
-done
-$NVCC -DALPAKA_ACC_GPU_CUDA_ENABLED $NVCC_FLAGS -shared cuda_*.o -o $CUPLA_ROOT/lib/libcupla-cuda.so
+CXX_FLAGS="-m64 -std=c++11 -g -O2 -DALPAKA_DEBUG=0 -DCUPLA_STREAM_ASYNC_ENABLED=1 -I$CUDA_ROOT/include -I$ALPAKA_ROOT/include -I$CUPLA_ROOT/include"
+HOST_FLAGS="-fPIC -ftemplate-depth-512 -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-attributes -Wno-reorder -Wno-sign-compare"
+NVCC_FLAGS="-lineinfo --expt-extended-lambda --expt-relaxed-constexpr --generate-code arch=compute_50,code=sm_50 --use_fast_math --ftz=false --cudart shared"
 
+mkdir -p $CUPLA_ROOT/build/cuda
+cd $CUPLA_ROOT/build/cuda
 for FILE in $FILES; do
-  $CXX -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $CXX_FLAGS -c $FILE -o serial_$(basename $FILE).o
+  nvcc -DALPAKA_ACC_GPU_CUDA_ENABLED $CXX_FLAGS $NVCC_FLAGS -Xcompiler "$HOST_FLAGS" -x cu -c $FILE -o $(basename $FILE).o
 done
-$CXX -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $CXX_FLAGS -shared serial_*.o -o $CUPLA_ROOT/lib/libcupla-serial.so
+nvcc -DALPAKA_ACC_GPU_CUDA_ENABLED $CXX_FLAGS $NVCC_FLAGS -Xcompiler "$HOST_FLAGS" -shared *.o -o $CUPLA_ROOT/lib/libcupla-cuda.so
 
+mkdir -p $CUPLA_ROOT/build/serial
+cd $CUPLA_ROOT/build/serial
+for FILE in $FILES; do
+  g++ -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $CXX_FLAGS $HOST_FLAGS -c $FILE -o $(basename $FILE).o
+done
+g++ -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $CXX_FLAGS $HOST_FLAGS -shared *.o -o $CUPLA_ROOT/lib/libcupla-serial.so
+
+mkdir -p $CUPLA_ROOT/build/tbb
+cd $CUPLA_ROOT/build/tbb
+for FILE in $FILES; do
+  g++ -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $CXX_FLAGS $HOST_FLAGS -c $FILE -o $(basename $FILE).o
+done
+g++ -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $CXX_FLAGS $HOST_FLAGS -shared *.o -ltbbmalloc -ltbb -lpthread -lrt -o $CUPLA_ROOT/lib/libcupla-tbb.so
 ```
 
 ## How to add a new implementation?

--- a/cupla.patch
+++ b/cupla.patch
@@ -1,0 +1,26 @@
+diff --git a/include/cupla/traits/IsThreadSeqAcc.hpp b/include/cupla/traits/IsThreadSeqAcc.hpp
+index eefb8a6..07d13f3 100644
+--- a/include/cupla/traits/IsThreadSeqAcc.hpp
++++ b/include/cupla/traits/IsThreadSeqAcc.hpp
+@@ -72,5 +72,21 @@ namespace traits
+     };
+ #endif
+ 
++#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
++    template<
++        typename T_KernelDim,
++        typename T_IndexType
++    >
++    struct IsThreadSeqAcc<
++        ::alpaka::acc::AccCpuTbbBlocks<
++            T_KernelDim,
++            T_IndexType
++        >
++    >
++    {
++        static constexpr bool value = true;
++    };
++#endif
++
+ }  // namespace traits
+ } // namespace cupla

--- a/main.cc
+++ b/main.cc
@@ -108,6 +108,7 @@ int main() {
     cudaFreeHost(output_h);
     cudaFreeHost(input_h);
 #elif defined DIGI_CUPLA
+#if defined ALPAKA_ACC_GPU_CUDA_ENABLED
     Input *input_d, *input_h;
     cuplaCheck(cuplaMalloc((void **) &input_d, sizeof(Input)));
     cuplaCheck(cuplaMallocHost((void **) &input_h, sizeof(Input)));
@@ -138,6 +139,14 @@ int main() {
     cuplaFree(input_d);
     cuplaFreeHost(output_h);
     cuplaFreeHost(input_h);
+#else // ALPAKA_ACC_GPU_CUDA_ENABLED
+    auto start = std::chrono::high_resolution_clock::now();
+    cupla::rawtodigi(&input, output.get(),
+                    input.wordCounter,
+                    true, true, false, stream);
+    cuplaCheck(cuplaStreamSynchronize(stream));
+    auto stop = std::chrono::high_resolution_clock::now();
+#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
 #endif
 
     auto diff = stop - start;

--- a/rawtodigi_cupla.cc
+++ b/rawtodigi_cupla.cc
@@ -387,10 +387,10 @@ namespace cupla {
     GPU::SimpleVector<PixelErrorCompact>* err = &output->err;
 
 
-    int32_t first = threadIdx.x + blockIdx.x*blockDim.x;
-    for (int32_t iloop=first, nend=wordCounter; iloop<nend; iloop+=blockDim.x*gridDim.x) { 
-
-        auto gIndex  = iloop;
+    int32_t first = (threadIdx.x + blockIdx.x * blockDim.x) * elemDim.x;
+    for (int32_t iloop = first; iloop < wordCounter; iloop += gridDim.x * blockDim.x * elemDim.x) {
+      int32_t last = std::min(iloop + elemDim.x, wordCounter);
+      for (auto gIndex = iloop; gIndex < last; ++gIndex) {
         xx[gIndex]   = 0;
         yy[gIndex]   = 0;
         adc[gIndex]  = 0;
@@ -488,6 +488,7 @@ namespace cupla {
         pdigi[gIndex] = pack(globalPix.row, globalPix.col, adc[gIndex]);
         moduleId[gIndex] = detId.moduleId;
         rawIdArr[gIndex] = rawId;
+      }
     } // end of loop (gIndex < end)
 
   } // end of Raw to Digi kernel


### PR DESCRIPTION
This PR:
  - adds support for the block-parallel TBB backend running on the cpu [1]
  - optimises the kernel for running on the cpu (both serially and with TBB) following the _cupla_ [tuning guide](https://github.com/ComputationalRadiationPhysics/cupla/blob/master/doc/TuningGuide.md)
  - avoids memory copies when using a cpu backend, for a fair comparison with the "naive" version

[1] automatic support for TBB requires a patch to _cupla_, similar to what is used for some other cpu backends:
```diff
diff --git a/include/cupla/traits/IsThreadSeqAcc.hpp b/include/cupla/traits/IsThreadSeqAcc.hpp
index eefb8a6..07d13f3 100644
--- a/include/cupla/traits/IsThreadSeqAcc.hpp
+++ b/include/cupla/traits/IsThreadSeqAcc.hpp
@@ -72,5 +72,21 @@ namespace traits
     };
 #endif
 
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    template<
+        typename T_KernelDim,
+        typename T_IndexType
+    >
+    struct IsThreadSeqAcc<
+        ::alpaka::acc::AccCpuTbbBlocks<
+            T_KernelDim,
+            T_IndexType
+        >
+    >
+    {
+        static constexpr bool value = true;
+    };
+#endif
+
 }  // namespace traits
 } // namespace cupla                                                                                                                                                                                                                        
```