### PR TITLE
Miscellaneous clean up

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+ColumnLimit:     120
+#didn't we want to change this?
+NamespaceIndentation: All
+SortIncludes:    false
+IndentWidth:     2
+AccessModifierOffset: -2
+PenaltyBreakComment: 30
+PenaltyExcessCharacter: 100
+AlignAfterOpenBracket: Align
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: false
+AlwaysBreakTemplateDeclarations: Yes
+ReflowComments: false
+BinPackArguments: false
+BinPackParameters: false

--- a/main_cuda.cc
+++ b/main_cuda.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "input.h"
+#include "modules.h"
 #include "output.h"
 
 #include <cuda_runtime.h>
@@ -12,27 +13,6 @@
 
 namespace {
   constexpr int NLOOPS = 100;
-}
-
-namespace gpuClustering {
-  constexpr uint32_t MaxNumModules  = 2000;
-  constexpr uint16_t InvId          = 9999;         // must be > MaxNumModules
-}
-
-int countModules(const uint16_t *id, int numElements) {
-  int nmod = 0;
-  for(int i=0; i<numElements; ++i) {
-    if(id[i] == gpuClustering::InvId)
-      continue;
-    auto j = i-1;
-    while(j >= 0 and id[j] == gpuClustering::InvId) {
-      --j;
-    }
-    if(j < 0 or id[j] != id[i]) {
-      ++nmod;
-    }
-  }
-  return nmod;
 }
 
 int main(int argc, char **argv) {

--- a/main_cupla.cc
+++ b/main_cupla.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "input.h"
+#include "modules.h"
 #include "output.h"
 
 /* Do NOT include other headers that use CUDA runtime functions or variables
@@ -17,27 +18,6 @@
 
 namespace {
   constexpr int NLOOPS = 100;
-}
-
-namespace gpuClustering {
-  constexpr uint32_t MaxNumModules  = 2000;
-  constexpr uint16_t InvId          = 9999;         // must be > MaxNumModules
-}
-
-int countModules(const uint16_t *id, int numElements) {
-  int nmod = 0;
-  for(int i=0; i<numElements; ++i) {
-    if(id[i] == gpuClustering::InvId)
-      continue;
-    auto j = i-1;
-    while(j >= 0 and id[j] == gpuClustering::InvId) {
-      --j;
-    }
-    if(j < 0 or id[j] != id[i]) {
-      ++nmod;
-    }
-  }
-  return nmod;
 }
 
 int main(int argc, char **argv) {

--- a/main_kokkos.cc
+++ b/main_kokkos.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "input.h"
+#include "modules.h"
 #include "output.h"
 
 #include <Kokkos_Core.hpp>
@@ -11,27 +12,6 @@
 
 namespace {
   constexpr int NLOOPS = 100;
-}
-
-namespace gpuClustering {
-  constexpr uint32_t MaxNumModules  = 2000;
-  constexpr uint16_t InvId          = 9999;         // must be > MaxNumModules
-}
-
-int countModules(const uint16_t *id, int numElements) {
-  int nmod = 0;
-  for(int i=0; i<numElements; ++i) {
-    if(id[i] == gpuClustering::InvId)
-      continue;
-    auto j = i-1;
-    while(j >= 0 and id[j] == gpuClustering::InvId) {
-      --j;
-    }
-    if(j < 0 or id[j] != id[i]) {
-      ++nmod;
-    }
-  }
-  return nmod;
 }
 
 int main(int argc, char **argv) {

--- a/main_naive.cc
+++ b/main_naive.cc
@@ -4,33 +4,13 @@
 #include <cstring>
 
 #include "input.h"
+#include "modules.h"
 #include "output.h"
 
 #include "rawtodigi_naive.h"
 
 namespace {
   constexpr int NLOOPS = 100;
-}
-
-namespace gpuClustering {
-  constexpr uint32_t MaxNumModules  = 2000;
-  constexpr uint16_t InvId          = 9999;         // must be > MaxNumModules
-}
-
-int countModules(const uint16_t *id, int numElements) {
-  int nmod = 0;
-  for(int i=0; i<numElements; ++i) {
-    if(id[i] == gpuClustering::InvId)
-      continue;
-    auto j = i-1;
-    while(j >= 0 and id[j] == gpuClustering::InvId) {
-      --j;
-    }
-    if(j < 0 or id[j] != id[i]) {
-      ++nmod;
-    }
-  }
-  return nmod;
 }
 
 int main(int argc, char **argv) {

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -7,32 +7,12 @@
 #include <dpct/dpct.hpp>
 
 #include "input.h"
+#include "modules.h"
 #include "output.h"
 #include "rawtodigi_oneapi.h"
 
 namespace {
   constexpr int NLOOPS = 100;
-}
-
-namespace gpuClustering {
-  constexpr uint32_t MaxNumModules  = 2000;
-  constexpr uint16_t InvId          = 9999;         // must be > MaxNumModules
-}
-
-int countModules(const uint16_t *id, int numElements) {
-  int nmod = 0;
-  for(int i=0; i<numElements; ++i) {
-    if(id[i] == gpuClustering::InvId)
-      continue;
-    auto j = i-1;
-    while(j >= 0 and id[j] == gpuClustering::InvId) {
-      --j;
-    }
-    if(j < 0 or id[j] != id[i]) {
-      ++nmod;
-    }
-  }
-  return nmod;
 }
 
 int main(int argc, char **argv) {

--- a/modules.h
+++ b/modules.h
@@ -1,0 +1,26 @@
+#ifndef moduels_h
+#define moduels_h
+
+namespace gpuClustering {
+  constexpr uint32_t MaxNumModules = 2000;
+  constexpr uint16_t InvId = 9999;  // must be > MaxNumModules
+}  // namespace gpuClustering
+
+inline
+int countModules(const uint16_t *id, int size) {
+  int modules = 0;
+  for (int i = 0; i < size; ++i) {
+    if (id[i] == gpuClustering::InvId)
+      continue;
+    auto j = i - 1;
+    while (j >= 0 and id[j] == gpuClustering::InvId) {
+      --j;
+    }
+    if (j < 0 or id[j] != id[i]) {
+      ++modules;
+    }
+  }
+  return modules;
+}
+
+#endif  // moduels_h

--- a/modules.h
+++ b/modules.h
@@ -1,5 +1,5 @@
-#ifndef moduels_h
-#define moduels_h
+#ifndef modules_h
+#define modules_h
 
 namespace gpuClustering {
   constexpr uint32_t MaxNumModules = 2000;
@@ -23,4 +23,4 @@ int countModules(const uint16_t *id, int size) {
   return modules;
 }
 
-#endif  // moduels_h
+#endif  // modules_h

--- a/output.h
+++ b/output.h
@@ -1,13 +1,13 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 
+#ifdef DIGI_NAIVE
 #include <vector>
-
-#include "pixelgpudetails.h"
-
-#if defined DIGI_CUDA || defined DIGI_CUPLA || defined DIGI_KOKKOS || defined DIGI_ONEAPI
+#elif defined DIGI_CUDA || defined DIGI_CUPLA || defined DIGI_KOKKOS || defined DIGI_ONEAPI
 #include "GPUSimpleVector.h"
 #endif
+
+#include "pixelgpudetails.h"
 
 struct alignas(128) Output {
   uint16_t xx[pixelgpudetails::MAX_FED_WORDS];

--- a/rawtodigi_kokkos.h
+++ b/rawtodigi_kokkos.h
@@ -362,21 +362,23 @@ namespace kokkos {
 
   template <typename InputView, typename OutputView>
   KOKKOS_INLINE_FUNCTION
-  void rawtodigi(const InputView& input, OutputView& output,
+  void rawtodigi(const InputView& inputView, OutputView& outputView,
                  const uint32_t wordCounter,
                  bool useQualityInfo, bool includeErrors, bool debug,
                  const int32_t index)
   {
-    const SiPixelFedCablingMapGPU* cablingMap = &(input(0).cablingMap);
-    const uint32_t* word = input(0).word;
-    const uint8_t* fedIds =input(0).fedId;
-    uint16_t* xx = output(0).xx;
-    uint16_t* yy = output(0).yy;
-    uint16_t* adc = output(0).adc;
-    uint32_t* pdigi = output(0).digi;
-    uint32_t* rawIdArr = output(0).rawIdArr;
-    uint16_t* moduleId = output(0).moduleInd;
-    GPU::SimpleVector<PixelErrorCompact>* err = &(output(0).err);
+    const Input* input = & inputView(0);
+    Ouput* output = & outputView(0);
+    const SiPixelFedCablingMapGPU* cablingMap = &input->cablingMap;
+    const uint32_t* word = input->word;
+    const uint8_t* fedIds = input->fedId;
+    uint16_t* xx = output->xx;
+    uint16_t* yy = output->yy;
+    uint16_t* adc = output->adc;
+    uint32_t* pdigi = output->digi;
+    uint32_t* rawIdArr = output->rawIdArr;
+    uint16_t* moduleId = output->moduleInd;
+    GPU::SimpleVector<PixelErrorCompact>* err = &output->err;
 
     int32_t first = index;
     for (int32_t iloop=first, nend=index+1; iloop<nend; ++iloop) {

--- a/rawtodigi_oneapi.h
+++ b/rawtodigi_oneapi.h
@@ -1,5 +1,5 @@
-#ifndef RAWTODIGI_CUDA_H
-#define RAWTODIGI_CUDA_H
+#ifndef RAWTODIGI_ONEAPI_H
+#define RAWTODIGI_ONEAPI_H
 
 #include <CL/sycl.hpp>
 
@@ -14,4 +14,4 @@ namespace oneapi {
                  bool useQualityInfo, bool includeErrors, bool debug, cl::sycl::queue queue);
 }
 
-#endif
+#endif  // RAWTODIGI_ONEAPI_H


### PR DESCRIPTION
Miscellaneous clean up:
  - `#include <vector>` only when used
  - move `countModules` to a common header
  - make the Kokkos code more similar to other implementations