### PR TITLE
Extend and update oneAPI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test-*
 debug-*
 build/
+env.sh

--- a/Makefile
+++ b/Makefile
@@ -464,10 +464,10 @@ oneapi-debug: debug-oneapi
 
 # oneAPI implementation
 test-oneapi: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) -O2 -std=c++14 -DDIGI_ONEAPI -DDIGI_ONEAPI_WORKAROUND -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+	$(ONEAPI_CXX) -O2 -std=c++14 -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
 
 debug-oneapi: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) -g -O2 -std=c++14 -DDIGI_ONEAPI -DDIGI_ONEAPI_WORKAROUND -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+	$(ONEAPI_CXX) -g -O2 -std=c++14 -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
 
 else
 oneapi:

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ CUPLA_DEBUG     := $(ALPAKA_DEBUG)
 CUPLA_LD_FLAGS  := -L$(CUPLA_BASE)/lib -lcupla
 
 # oneAPI flags
-ONEAPI_CXX := $(shell which dpcpp 2> /dev/null)
+#ONEAPI_CXX := $(shell which dpcpp 2> /dev/null)
+ONEAPI_CXX := /data/user/fwyzard/sycl/build/bin/clang++ -fsycl -I/opt/intel/inteloneapi/dpcpp-ct/latest/include
 
 # Kokkos flags
 # recommended to include only after the first target, see

--- a/Makefile
+++ b/Makefile
@@ -470,18 +470,18 @@ oneapi-debug: debug-oneapi debug-oneapi-cuda
 	@echo -e $(GREEN)oneAPI debug targets built$(RESET)
 
 # oneAPI implementation
-test-oneapi: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+test-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
-debug-oneapi: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+debug-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 ifdef ONEAPI_CUDA_PLUGIN
-test-oneapi-cuda: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+test-oneapi-cuda: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
-debug-oneapi-cuda: main_oneapi.cc rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc rawtodigi_oneapi.cc
+debug-oneapi-cuda: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 else
 test-oneapi-cuda:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The purpose of this test program is to experiment with various
 | Kokkos on CPU  | `kokkos`              | `main-kokkos-serial`            | `DIGI_KOKKOS`, `DIGI_KOKKOS_SERIAL`                                                   |
 |                |                       | `main-kokkos-openmp`            | `DIGI_KOKKOS`, `DIGI_KOKKOS_OPENMP`                                                   |
 | Kokkos on GPU  |                       | `main-kokkos-cuda`              | `DIGI_KOKKOS`, `DIGI_KOKKOS_CUDA`                                                     |
-| Intel oneAPI   | `oneapi`              | `main-oneapi`                   | `DIGI_ONEAPI`, `DIGI_ONEAPI_WORKAROUND`                                               |
+| Intel oneAPI   | `oneapi`              | `main-oneapi`                   | `DIGI_ONEAPI`                                                                         |
 
 
 The per-technology targets build all the executables of that

--- a/analyzer_oneapi.cc
+++ b/analyzer_oneapi.cc
@@ -1,0 +1,90 @@
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <memory>
+
+#include <CL/sycl.hpp>
+
+#include "input.h"
+#include "modules.h"
+#include "output.h"
+#include "rawtodigi_oneapi.h"
+
+namespace {
+  constexpr int NLOOPS = 100;
+}
+
+namespace oneapi {
+
+  void exception_handler(cl::sycl::exception_list exceptions) {
+    for (auto const &exc_ptr : exceptions) {
+      try {
+        std::rethrow_exception(exc_ptr);
+      } catch (cl::sycl::exception const &e) {
+        std::cerr << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
+      }
+    }
+  }
+
+  void analyze(cl::sycl::device device, Input const &input, Output &output, double &totaltime) {
+    cl::sycl::queue queue{device, exception_handler};
+
+    totaltime = 0;
+
+    for (int i = 0; i <= NLOOPS; ++i) {
+      output = Output{};
+
+      auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), queue);
+      if (input_d == nullptr) {
+        std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of device memory" << std::endl;
+        exit(1);
+      }
+      auto input_h = (Input *)cl::sycl::malloc_host(sizeof(Input), queue);
+      if (input_h == nullptr) {
+        std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of host memory" << std::endl;
+        exit(1);
+      }
+      std::memcpy(input_h, &input, sizeof(Input));
+
+      auto output_d = (Output *)cl::sycl::malloc_device(sizeof(Output), queue);
+      if (output_d == nullptr) {
+        std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of device memory" << std::endl;
+        exit(1);
+      }
+      auto output_h = (Output *)cl::sycl::malloc_host(sizeof(Output), queue);
+      if (output_h == nullptr) {
+        std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of host memory" << std::endl;
+        exit(1);
+      }
+      output_h->err.construct(pixelgpudetails::MAX_FED_WORDS, output_d->err_d);
+
+      auto start = std::chrono::high_resolution_clock::now();
+      queue.memcpy(input_d, input_h, sizeof(Input));
+      queue.memcpy(output_d, output_h, sizeof(Output));
+
+      rawtodigi(input_d, output_d, input.wordCounter, true, true, i == 0, queue);
+
+      queue.memcpy(output_h, output_d, sizeof(Output));
+      queue.wait_and_throw();
+      auto stop = std::chrono::high_resolution_clock::now();
+
+      output_h->err.set_data(output_h->err_d);
+      std::memcpy(&output, output_h, sizeof(Output));
+      output.err.set_data(output.err_d);
+
+      cl::sycl::free(output_d, queue);
+      cl::sycl::free(input_d, queue);
+      cl::sycl::free(output_h, queue);
+      cl::sycl::free(input_h, queue);
+
+      auto diff = stop - start;
+      auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      if (i != 0) {
+        totaltime += time;
+      }
+    }
+
+    totaltime /= NLOOPS;
+  }
+
+}  // namespace oneapi

--- a/analyzer_oneapi.h
+++ b/analyzer_oneapi.h
@@ -1,0 +1,13 @@
+#ifndef analyzer_oneapi_h_
+#define analyzer_oneapi_h_
+
+#include <CL/sycl.hpp>
+
+class Input;
+class Output;
+
+namespace oneapi {
+  void analyze(cl::sycl::device device, Input const &input, Output &output, double &totaltime);
+}
+
+#endif  // analyzer_oneapi_h_

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 #ifdef DIGI_ONEAPI_WORKAROUND
   output = std::make_unique<Output>();
 #endif  // DIGI_ONEAPI_WORKAROUND
-  for (int i = 0; i < NLOOPS; ++i) {
+  for (int i = 0; i <= NLOOPS; ++i) {
 #ifndef DIGI_ONEAPI_WORKAROUND
     output = std::make_unique<Output>();
 #endif  // ! DIGI_ONEAPI_WORKAROUND
@@ -127,7 +127,9 @@ int main(int argc, char **argv) {
 
     auto diff = stop - start;
     auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
-    totaltime += time;
+    if (i != 0) {
+      totaltime += time;
+    }
   }
 
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in "

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -5,26 +5,16 @@
 
 #include <CL/sycl.hpp>
 
+#include "analyzer_oneapi.h"
 #include "input.h"
 #include "modules.h"
 #include "output.h"
-#include "rawtodigi_oneapi.h"
 
 namespace {
   constexpr int NLOOPS = 100;
 }
 
 enum DeviceType { default_device = 0, host_device, cpu_device, gpu_device, cuda_device };
-
-void exception_handler(cl::sycl::exception_list exceptions) {
-  for (auto const &exc_ptr : exceptions) {
-    try {
-      std::rethrow_exception(exc_ptr);
-    } catch (cl::sycl::exception const &e) {
-      std::cerr << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
-    }
-  }
-}
 
 class cuda_selector : public cl::sycl::device_selector {
 public:
@@ -40,6 +30,7 @@ public:
 };
 
 int main(int argc, char **argv) {
+  /*
   DeviceType device_type = default_device;
   if (argc > 1) {
     if (std::strcmp(argv[1], "--host") == 0)
@@ -82,72 +73,23 @@ int main(int argc, char **argv) {
       device = cl::sycl::device{selector};
     }
   }
-
-  cl::sycl::queue queue{device, exception_handler};
-  std::cout << "Running on SYCL device " << device.get_info<cl::sycl::info::device::name>() << ", driver version "
-            << device.get_info<cl::sycl::info::device::driver_version>() << std::endl;
+  */
 
   Input input = read_input();
   std::cout << "Got " << input.cablingMap.size << " for cabling, wordCounter " << input.wordCounter << std::endl;
 
-  int totaltime = 0;
+  std::unique_ptr<Output> output = std::make_unique<Output>();
+  double totaltime = 0;
 
-  std::unique_ptr<Output> output;
-  for (int i = 0; i <= NLOOPS; ++i) {
-    output = std::make_unique<Output>();
-
-    auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), queue);
-    if (input_d == nullptr) {
-      std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of device memory" << std::endl;
-      exit(1);
-    }
-    auto input_h = (Input *)cl::sycl::malloc_host(sizeof(Input), queue);
-    if (input_h == nullptr) {
-      std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of host memory" << std::endl;
-      exit(1);
-    }
-    std::memcpy(input_h, &input, sizeof(Input));
-
-    auto output_d = (Output *)cl::sycl::malloc_device(sizeof(Output), queue);
-    if (output_d == nullptr) {
-      std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of device memory" << std::endl;
-      exit(1);
-    }
-    auto output_h = (Output *)cl::sycl::malloc_host(sizeof(Output), queue);
-    if (output_h == nullptr) {
-      std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of host memory" << std::endl;
-      exit(1);
-    }
-    output_h->err.construct(pixelgpudetails::MAX_FED_WORDS, output_d->err_d);
-
-    auto start = std::chrono::high_resolution_clock::now();
-    queue.memcpy(input_d, input_h, sizeof(Input));
-    queue.memcpy(output_d, output_h, sizeof(Output));
-
-    oneapi::rawtodigi(input_d, output_d, input.wordCounter, true, true, i == 0, queue);
-
-    queue.memcpy(output_h, output_d, sizeof(Output));
-    queue.wait_and_throw();
-    auto stop = std::chrono::high_resolution_clock::now();
-
-    output_h->err.set_data(output_h->err_d);
-    std::memcpy(output.get(), output_h, sizeof(Output));
-    output->err.set_data(output->err_d);
-
-    cl::sycl::free(output_d, queue);
-    cl::sycl::free(input_d, queue);
-    cl::sycl::free(output_h, queue);
-    cl::sycl::free(input_h, queue);
-
-    auto diff = stop - start;
-    auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
-    if (i != 0) {
-      totaltime += time;
-    }
+  auto devices = cl::sycl::device::get_devices();
+  for (auto & device: devices) {
+    std::cout << std::endl;
+    std::cout << "Running on SYCL device " << device.get_info<cl::sycl::info::device::name>() << ", driver version "
+              << device.get_info<cl::sycl::info::device::driver_version>() << std::endl;
+    oneapi::analyze(device, input, *output, totaltime);
+    std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in "
+              << (static_cast<double>(totaltime) / NLOOPS) << " us" << std::endl;
   }
-
-  std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in "
-            << (static_cast<double>(totaltime) / NLOOPS) << " us" << std::endl;
 
   return 0;
 }

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -4,7 +4,6 @@
 #include <memory>
 
 #include <CL/sycl.hpp>
-#include <dpct/dpct.hpp>
 
 #include "input.h"
 #include "modules.h"

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -14,66 +14,82 @@ namespace {
   constexpr int NLOOPS = 100;
 }
 
-enum DeviceType { default_device = 0, host_device, cpu_device, gpu_device, cuda_device };
+enum class DeviceType { all_devices = -1, default_device = 0, host_device, cpu_device, gpu_device, cuda_device };
 
 class cuda_selector : public cl::sycl::device_selector {
 public:
   int operator()(const cl::sycl::device & device) const override {
-    using namespace cl::sycl::info;
     std::string const& name = device.get_info<cl::sycl::info::device::name>();
     std::string const& vendor = device.get_info<cl::sycl::info::device::vendor>();
     if (device.is_gpu() and (name.find("NVIDIA") != std::string::npos or vendor.find("NVIDIA") != std::string::npos)) {
-      return 1;
+      return 1000;
     };
     return -1;
   }
 };
 
+template <typename T>
+cl::sycl::vector_class<cl::sycl::device> get_devices(T selector) {
+  auto const& all_devices = cl::sycl::device::get_devices();
+  cl::sycl::vector_class<cl::sycl::device> devices;
+  auto size = std::count_if(all_devices.begin(), all_devices.end(), [selector](cl::sycl::device device){ return selector(device) > 0; });
+  devices.reserve(size);
+  std::copy_if(all_devices.begin(), all_devices.end(), std::back_inserter(devices), [selector](cl::sycl::device device){ return selector(device) > 0; });
+  return devices;
+}
+
 int main(int argc, char **argv) {
-  /*
-  DeviceType device_type = default_device;
+  DeviceType device_type = DeviceType::all_devices;
   if (argc > 1) {
-    if (std::strcmp(argv[1], "--host") == 0)
-      device_type = host_device;
+    if (std::strcmp(argv[1], "--all") == 0)
+      device_type = DeviceType::all_devices;
+    else if (std::strcmp(argv[1], "--default") == 0)
+      device_type = DeviceType::default_device;
+    else if (std::strcmp(argv[1], "--host") == 0)
+      device_type = DeviceType::host_device;
     else if (std::strcmp(argv[1], "--cpu") == 0)
-      device_type = cpu_device;
+      device_type = DeviceType::cpu_device;
     else if (std::strcmp(argv[1], "--gpu") == 0)
-      device_type = gpu_device;
+      device_type = DeviceType::gpu_device;
     else if (std::strcmp(argv[1], "--cuda") == 0)
-      device_type = cuda_device;
+      device_type = DeviceType::cuda_device;
     else
       std::cout << "Ignoring unknown option " << argv[1] << std::endl;
   }
 
-  cl::sycl::device device;
+  cl::sycl::vector_class<cl::sycl::device> devices;
+
   switch (device_type) {
-    case host_device: {
-      cl::sycl::host_selector selector;
-      device = cl::sycl::device{selector};
+    case DeviceType::all_devices: {
+      devices = cl::sycl::device::get_devices();
       break;
     }
-    case cpu_device: {
-      cl::sycl::cpu_selector selector;
-      device = cl::sycl::device{selector};
-      break;
-    }
-    case gpu_device: {
-      cl::sycl::gpu_selector selector;
-      device = cl::sycl::device{selector};
-      break;
-    }
-    case cuda_device: {
-      cuda_selector selector;
-      device = cl::sycl::device{selector};
-      break;
-    }
-    case default_device:
-    default: {
+    case DeviceType::default_device: {
       cl::sycl::default_selector selector;
-      device = cl::sycl::device{selector};
+      devices.push_back(cl::sycl::device{selector});
+      break;
+    }
+    case DeviceType::host_device: {
+      cl::sycl::host_selector selector;
+      devices.push_back(cl::sycl::device{selector});
+      break;
+    }
+    case DeviceType::cpu_device: {
+      cl::sycl::cpu_selector selector;
+      devices = ::get_devices(selector);
+      break;
+    }
+    case DeviceType::gpu_device: {
+      cl::sycl::gpu_selector selector;
+      devices = ::get_devices(selector);
+      break;
+    }
+    case DeviceType::cuda_device: {
+      cuda_selector selector;
+      devices = ::get_devices(selector);
+      break;
     }
   }
-  */
 
   Input input = read_input();
   std::cout << "Got " << input.cablingMap.size << " for cabling, wordCounter " << input.wordCounter << std::endl;
@@ -81,7 +97,6 @@ int main(int argc, char **argv) {
   std::unique_ptr<Output> output = std::make_unique<Output>();
   double totaltime = 0;
 
-  auto devices = cl::sycl::device::get_devices();
   for (auto & device: devices) {
     std::cout << std::endl;
     std::cout << "Running on SYCL device " << device.get_info<cl::sycl::info::device::name>() << ", driver version "

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -14,7 +14,7 @@ namespace {
   constexpr int NLOOPS = 100;
 }
 
-enum DeviceType { default_device = 0, host_device, cpu_device, gpu_device };
+enum DeviceType { default_device = 0, host_device, cpu_device, gpu_device, cuda_device };
 
 void exception_handler(cl::sycl::exception_list exceptions) {
   for (auto const &exc_ptr : exceptions) {
@@ -26,6 +26,19 @@ void exception_handler(cl::sycl::exception_list exceptions) {
   }
 }
 
+class cuda_selector : public cl::sycl::device_selector {
+public:
+  int operator()(const cl::sycl::device & device) const override {
+    using namespace cl::sycl::info;
+    std::string const& name = device.get_info<cl::sycl::info::device::name>();
+    std::string const& vendor = device.get_info<cl::sycl::info::device::vendor>();
+    if (device.is_gpu() and (name.find("NVIDIA") != std::string::npos or vendor.find("NVIDIA") != std::string::npos)) {
+      return 1;
+    };
+    return -1;
+  }
+};
+
 int main(int argc, char **argv) {
   DeviceType device_type = default_device;
   if (argc > 1) {
@@ -35,6 +48,8 @@ int main(int argc, char **argv) {
       device_type = cpu_device;
     else if (std::strcmp(argv[1], "--gpu") == 0)
       device_type = gpu_device;
+    else if (std::strcmp(argv[1], "--cuda") == 0)
+      device_type = cuda_device;
     else
       std::cout << "Ignoring unknown option " << argv[1] << std::endl;
   }
@@ -42,24 +57,29 @@ int main(int argc, char **argv) {
   cl::sycl::device device;
   switch (device_type) {
     case host_device: {
-      cl::sycl::host_selector device_selector;
-      device = cl::sycl::device{device_selector};
+      cl::sycl::host_selector selector;
+      device = cl::sycl::device{selector};
       break;
     }
     case cpu_device: {
-      cl::sycl::cpu_selector device_selector;
-      device = cl::sycl::device{device_selector};
+      cl::sycl::cpu_selector selector;
+      device = cl::sycl::device{selector};
       break;
     }
     case gpu_device: {
-      cl::sycl::gpu_selector device_selector;
-      device = cl::sycl::device{device_selector};
+      cl::sycl::gpu_selector selector;
+      device = cl::sycl::device{selector};
+      break;
+    }
+    case cuda_device: {
+      cuda_selector selector;
+      device = cl::sycl::device{selector};
       break;
     }
     case default_device:
     default: {
-      cl::sycl::default_selector device_selector;
-      device = cl::sycl::device{device_selector};
+      cl::sycl::default_selector selector;
+      device = cl::sycl::device{selector};
     }
   }
 

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
   }
 
   cl::sycl::queue queue{device, exception_handler};
-  cl::sycl::context ctx = (device_type == cpu_device) ? cl::sycl::context{device} : queue.get_context();
+  cl::sycl::context ctx = queue.get_context();
   std::cout << "Running on SYCL device " << device.get_info<cl::sycl::info::device::name>() << ", driver version "
             << device.get_info<cl::sycl::info::device::driver_version>() << std::endl;
 

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
     queue.memcpy(input_d, input_h, sizeof(Input));
     queue.memcpy(output_d, output_h, sizeof(Output));
 
-    oneapi::rawtodigi(input_d, output_d, input.wordCounter, true, true, false, i == 0, queue);
+    oneapi::rawtodigi(input_d, output_d, input.wordCounter, true, true, i == 0, queue);
 
     queue.memcpy(output_h, output_d, sizeof(Output));
     queue.wait_and_throw();

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -63,8 +63,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  cl::sycl::context ctx{device};
   cl::sycl::queue queue{device, exception_handler};
+  cl::sycl::context ctx = (device_type == cpu_device) ? cl::sycl::context{device} : queue.get_context();
   std::cout << "Running on SYCL device " << device.get_info<cl::sycl::info::device::name>() << ", driver version "
             << device.get_info<cl::sycl::info::device::driver_version>() << std::endl;
 

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -74,13 +74,8 @@ int main(int argc, char **argv) {
   int totaltime = 0;
 
   std::unique_ptr<Output> output;
-#ifdef DIGI_ONEAPI_WORKAROUND
-  output = std::make_unique<Output>();
-#endif  // DIGI_ONEAPI_WORKAROUND
   for (int i = 0; i <= NLOOPS; ++i) {
-#ifndef DIGI_ONEAPI_WORKAROUND
     output = std::make_unique<Output>();
-#endif  // ! DIGI_ONEAPI_WORKAROUND
 
     auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), device, ctx);
     if (input_d == nullptr) {

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
     queue.memcpy((void *)input_d, (void *)input_h, sizeof(Input));
     queue.memcpy((void *)output_d, (void *)output_h, sizeof(Output));
 
-    oneapi::rawtodigi(input_d, output_d, input.wordCounter, true, true, false, queue);
+    oneapi::rawtodigi(input_d, output_d, input.wordCounter, true, true, false, i == 0, queue);
 
     queue.memcpy((void *)output_h, (void *)output_d, sizeof(Output));
     queue.wait_and_throw();

--- a/rawtodigi_oneapi.cc
+++ b/rawtodigi_oneapi.cc
@@ -492,7 +492,13 @@ namespace oneapi {
                  bool useQualityInfo,
                  bool includeErrors,
                  bool debug,
+#if __SYCL_COMPILER_VERSION <= 20200118
+                 // Intel oneAPI beta 4
+                 cl::sycl::ordered_queue queue) try {
+#else
+                 // Intel SYCL branch
                  cl::sycl::queue queue) try {
+#endif
     const uint32_t blockSize = std::min({queue.get_device().get_info<cl::sycl::info::device::max_work_group_size>(),
                                          queue.get_device().get_info<cl::sycl::info::device::max_work_item_sizes>()[0],
                                          4096ul});  // upper limit from trial and error

--- a/rawtodigi_oneapi.cc
+++ b/rawtodigi_oneapi.cc
@@ -157,7 +157,6 @@ namespace oneapi {
   }
 
   uint8_t conversionError(uint8_t fedId, uint8_t status, bool debug, cl::sycl::stream out) {
-#ifndef DIGI_ONEAPI_WORKAROUND
     if (debug) {
       switch (status) {
         case (1): {
@@ -180,7 +179,6 @@ namespace oneapi {
           out << "Cabling check returned unexpected result, status = " << status << cl::sycl::endl;
       };
     }
-#endif  // DIGI_ONEAPI_WORKAROUND
 
     if (status >= 1 and status <= 4) {
       return status + 34;

--- a/rawtodigi_oneapi.cc
+++ b/rawtodigi_oneapi.cc
@@ -478,6 +478,7 @@ namespace oneapi {
                  bool useQualityInfo,
                  bool includeErrors,
                  bool debug,
+                 bool first,
                  cl::sycl::queue queue) try {
     const uint32_t blockSize = std::min({queue.get_device().get_info<cl::sycl::info::device::max_work_group_size>(),
                                          queue.get_device().get_info<cl::sycl::info::device::max_work_item_sizes>()[0],
@@ -485,6 +486,9 @@ namespace oneapi {
     const uint32_t blocks = std::min((wordCounter + blockSize - 1) / blockSize,
                                      queue.get_device().get_info<cl::sycl::info::device::max_compute_units>());
     const uint32_t threads = blocks * blockSize;
+    if (first) {
+      std::cout << "work groups: " << blocks << ", work items per group: " << blockSize << std::endl;
+    }
     queue.submit([&](cl::sycl::handler& cgh) {
       cl::sycl::stream out(64 * 1024, 80, cgh);
       cgh.parallel_for<rawtodigi_kernel_name>(

--- a/rawtodigi_oneapi.h
+++ b/rawtodigi_oneapi.h
@@ -14,7 +14,13 @@ namespace oneapi {
                  bool useQualityInfo,
                  bool includeErrors,
                  bool debug,
+#if __SYCL_COMPILER_VERSION <= 20200118
+                 // Intel oneAPI beta 4
+                 cl::sycl::ordered_queue queue);
+#else
+                 // Intel SYCL branch
                  cl::sycl::queue queue);
+#endif
 
 }  // namespace oneapi
 

--- a/rawtodigi_oneapi.h
+++ b/rawtodigi_oneapi.h
@@ -3,15 +3,13 @@
 
 #include <CL/sycl.hpp>
 
-#include "GPUSimpleVector.h"
-#include "input.h"
-#include "output.h"
-#include "pixelgpudetails.h"
+class Input;
+class Output;
 
 namespace oneapi {
 
-  void rawtodigi(const Input *input_d,
-                 Output *output_d,
+  void rawtodigi(const Input* input,
+                 Output* output,
                  const uint32_t wordCounter,
                  bool useQualityInfo,
                  bool includeErrors,

--- a/rawtodigi_oneapi.h
+++ b/rawtodigi_oneapi.h
@@ -14,7 +14,6 @@ namespace oneapi {
                  bool useQualityInfo,
                  bool includeErrors,
                  bool debug,
-                 bool first,
                  cl::sycl::queue queue);
 
 }  // namespace oneapi

--- a/rawtodigi_oneapi.h
+++ b/rawtodigi_oneapi.h
@@ -16,6 +16,7 @@ namespace oneapi {
                  bool useQualityInfo,
                  bool includeErrors,
                  bool debug,
+                 bool first,
                  cl::sycl::queue queue);
 
 }  // namespace oneapi


### PR DESCRIPTION
Update the code structure splitting the main and analyzer parts. 
Update to the API and features available in oneAPI beta 4.
Add support for building with the Intel and Codeplay open source implementations.
Run over all available devices, or those selected based on the command line argument.
Use an in-order queue to serialise the memory operations and kernel launch.