### PR TITLE
Update the Alpaka, Cupla, CUDA and naive analysers

### DIFF
--- a/analyzer_alpaka.cc
+++ b/analyzer_alpaka.cc
@@ -23,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     totaltime = 0.;
 
-    for (int i = 0; i < NLOOPS; i++) {
+    for (int i = 0; i <= NLOOPS; i++) {
       output = Output();
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -64,7 +64,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       alpaka::queue::enqueue(
           queue,
-          alpaka::kernel::createTaskKernel<Acc>(workDiv, rawtodigi_kernel(), input_d, output_d, true, true, false));
+          alpaka::kernel::createTaskKernel<Acc>(workDiv, rawtodigi_kernel(), input_d, output_d, true, true, i == 0));
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
       alpaka::mem::view::copy(queue, output_hBuf, output_dBuf, size);
@@ -81,7 +81,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
       auto diff = stop - start;
-      totaltime += std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      if (i != 0) {
+        totaltime += time;
+      }
     }
 
     totaltime /= NLOOPS;

--- a/analyzer_alpaka.cc
+++ b/analyzer_alpaka.cc
@@ -61,6 +61,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::swap(threadsPerBlock, elementsPerThread);
 #endif
       const WorkDiv workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
+      if (i == 0) {
+        std::cout << "blocks per grid: " << blocksPerGrid << ", threads per block: " << threadsPerBlock << ", elements per thread: " << elementsPerThread << std::endl;
+      }
 
       alpaka::queue::enqueue(
           queue,

--- a/analyzer_cuda.cc
+++ b/analyzer_cuda.cc
@@ -24,7 +24,7 @@ namespace cuda {
 
     totaltime = 0;
 
-    for (int i = 0; i < NLOOPS; ++i) {
+    for (int i = 0; i <= NLOOPS; ++i) {
       output = Output();
 
       Input *input_d, *input_h;
@@ -43,7 +43,7 @@ namespace cuda {
 
       const int threadsPerBlock = 512;
       const int blocks = (input.wordCounter + threadsPerBlock - 1) / threadsPerBlock;
-      cute::launch(cuda::rawtodigi_kernel, {blocks, threadsPerBlock, 0, stream}, input_d, output_d, true, true, false);
+      cute::launch(cuda::rawtodigi_kernel, {blocks, threadsPerBlock, 0, stream}, input_d, output_d, true, true, i == 0);
 
       CUTE_CHECK(cudaMemcpyAsync(output_h, output_d, sizeof(Output), cudaMemcpyDefault, stream));
       CUTE_CHECK(cudaStreamSynchronize(stream));
@@ -59,7 +59,10 @@ namespace cuda {
       CUTE_CHECK(cudaFreeHost(input_h));
 
       auto diff = stop - start;
-      totaltime += std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      if (i != 0) {
+        totaltime += time;
+      }
     }
 
     totaltime /= NLOOPS;

--- a/analyzer_cuda.cc
+++ b/analyzer_cuda.cc
@@ -43,6 +43,9 @@ namespace cuda {
 
       const int threadsPerBlock = 512;
       const int blocks = (input.wordCounter + threadsPerBlock - 1) / threadsPerBlock;
+      if (i == 0) {
+        std::cout << "blocks per grid: " << blocks << ", threads per block: " << threadsPerBlock << std::endl;
+      }
       cute::launch(cuda::rawtodigi_kernel, {blocks, threadsPerBlock, 0, stream}, input_d, output_d, true, true, i == 0);
 
       CUTE_CHECK(cudaMemcpyAsync(output_h, output_d, sizeof(Output), cudaMemcpyDefault, stream));

--- a/analyzer_cupla.cc
+++ b/analyzer_cupla.cc
@@ -55,7 +55,9 @@ namespace CUPLA_ACCELERATOR_NAMESPACE {
 
       const int threadsPerBlock = 512;
       const int blocks = (input.wordCounter + threadsPerBlock - 1) / threadsPerBlock;
-
+      if (i == 0) {
+        std::cout << "blocks per grid: " << blocks << ", threads per block: " << threadsPerBlock << std::endl;
+      }
       CUPLA_KERNEL_OPTI(CUPLA_ACCELERATOR_NAMESPACE::rawtodigi_kernel)
       (blocks, threadsPerBlock, 0, stream)(input_d, output_d, true, true, i == 0);
       CUPLA_CHECK(cudaGetLastError());

--- a/analyzer_cupla.cc
+++ b/analyzer_cupla.cc
@@ -28,7 +28,7 @@ namespace CUPLA_ACCELERATOR_NAMESPACE {
 
     totaltime = 0;
 
-    for (int i = 0; i < NLOOPS; ++i) {
+    for (int i = 0; i <= NLOOPS; ++i) {
       output = Output();
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -57,7 +57,7 @@ namespace CUPLA_ACCELERATOR_NAMESPACE {
       const int blocks = (input.wordCounter + threadsPerBlock - 1) / threadsPerBlock;
 
       CUPLA_KERNEL_OPTI(CUPLA_ACCELERATOR_NAMESPACE::rawtodigi_kernel)
-      (blocks, threadsPerBlock, 0, stream)(input_d, output_d, true, true, false);
+      (blocks, threadsPerBlock, 0, stream)(input_d, output_d, true, true, i == 0);
       CUPLA_CHECK(cudaGetLastError());
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -78,7 +78,10 @@ namespace CUPLA_ACCELERATOR_NAMESPACE {
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
       auto diff = stop - start;
-      totaltime += std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
+      if (i != 0) {
+        totaltime += time;
+      }
     }
 
     totaltime /= NLOOPS;

--- a/analyzer_naive.cc
+++ b/analyzer_naive.cc
@@ -11,7 +11,7 @@ namespace {
 
 namespace naive {
   void analyze(Input const& input, std::unique_ptr<Output>& output, double& totaltime) {
-    for (int i = 0; i < NLOOPS; ++i) {
+    for (int i = 0; i <= NLOOPS; ++i) {
       output = std::make_unique<Output>();
 
       auto start = std::chrono::high_resolution_clock::now();
@@ -28,12 +28,14 @@ namespace naive {
                        &output->err,
                        true,
                        true,
-                       false);
+                       i == 0);
       auto stop = std::chrono::high_resolution_clock::now();
 
       auto diff = stop - start;
       auto time = std::chrono::duration_cast<std::chrono::microseconds>(diff).count();
-      totaltime += time;
+      if (i != 0) {
+        totaltime += time;
+      }
     }
 
     totaltime /= NLOOPS;


### PR DESCRIPTION
Print the kernel launch parameters and enable debug in the kernel during the first iteration.
Skip the first iteration when measuring the run time.