### PR TITLE
Add support the OpenMP 4.0 backend for Apaka and Cupla

### DIFF
--- a/GPUSimpleVector.h
+++ b/GPUSimpleVector.h
@@ -9,7 +9,7 @@
 #if defined DIGI_CUDA
 #include <cuda.h>
 #elif defined DIGI_ALPAKA
-#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #include <alpaka/alpaka.hpp>
 #endif  // ALPAKA_ACC_*_ENABLED
 #elif defined DIGI_CUPLA
@@ -18,7 +18,7 @@
  * built-in variables using macros and macro functions.
  * Do NOT include other specific includes such as `<cuda.h>`, etc.
  */
-#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #include <cuda_to_cupla.hpp>
 #endif  // ALPAKA_ACC_*_ENABLED
 #elif defined DIGI_KOKKOS
@@ -99,7 +99,7 @@ namespace GPU {
     }
 
 #elif defined DIGI_ALPAKA
-#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
 
     template <typename T_Acc>
     ALPAKA_FN_ACC int push_back(T_Acc const &acc, const T &element) {
@@ -127,7 +127,7 @@ namespace GPU {
 
 #endif  // ALPAKA_ACC_*_ENABLED
 #elif defined DIGI_CUPLA
-#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#if defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_CUDA_ENABLED
 
     template <typename T_Acc>
     ALPAKA_FN_ACC int push_back(T_Acc const &acc, const T &element) {

--- a/alpakaConfig.h
+++ b/alpakaConfig.h
@@ -81,4 +81,21 @@ namespace alpaka_omp2_async {
 #define ALPAKA_ACCELERATOR_NAMESPACE alpaka_omp2_async
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 
+#ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#define ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+namespace alpaka_omp4_async {
+  using namespace alpaka_common;
+  using Acc = alpaka::acc::AccCpuOmp4<Dim, Extent>;
+  using DevAcc = alpaka::dev::Dev<Acc>;
+  using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+  using Queue = alpaka::queue::QueueCpuNonBlocking;
+}  // namespace alpaka_omp4_async
+
+#endif  // ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+#define ALPAKA_ARCHITECTURE_NAMESPACE alpaka_cpu
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_omp4_async
+#endif  // ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+
 #endif  // alpakaConfig_h_

--- a/analyzer_alpaka.cc
+++ b/analyzer_alpaka.cc
@@ -55,7 +55,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       Vec elementsPerThread(Vec::all(1));
       Vec threadsPerBlock(Vec::all(512));
       Vec blocksPerGrid(Vec::all((input.wordCounter + 512 - 1) / 512));
-#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED || ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED || ALPAKA_ACC_CPU_BT_OMP4_ENABLED
       // on the GPU, run with 512 threads in parallel per block, each looking at a single element
       // on the CPU, run serially with a single thread per block, over 512 elements
       std::swap(threadsPerBlock, elementsPerThread);

--- a/analyzer_alpaka.h
+++ b/analyzer_alpaka.h
@@ -16,6 +16,10 @@ namespace alpaka_omp2_async {
   void analyze(Input const& input, Output& output, double& totaltime);
 }
 
+namespace alpaka_omp4_async {
+  void analyze(Input const& input, Output& output, double& totaltime);
+}
+
 namespace alpaka_cuda_async {
   void analyze(Input const& input, Output& output, double& totaltime);
 }

--- a/analyzer_cupla.h
+++ b/analyzer_cupla.h
@@ -20,6 +20,10 @@ namespace cupla_omp2_seq_async {
   void analyze(Input const& input, Output& output, double& totaltime);
 }
 
+namespace cupla_omp4_omp4_async {
+  void analyze(Input const& input, Output& output, double& totaltime);
+}
+
 namespace cupla_cuda_async {
   void analyze(Input const& input, Output& output, double& totaltime);
 }

--- a/main_alpaka.cc
+++ b/main_alpaka.cc
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the blocking CPU serial backend..." << std::endl;
+  std::cout << "\nRunning with the blocking serial CPU backend..." << std::endl;
   alpaka_serial_sync::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking CPU TBB parallel backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking TBB CPU backend..." << std::endl;
   alpaka_tbb_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
@@ -31,15 +31,23 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking CPU OpenMP 2.0 backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking OpenMP 2.0 blocks CPU backend..." << std::endl;
   alpaka_omp2_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 
+#ifdef ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+  output = std::make_unique<Output>();
+  std::cout << "\nRunning with the non-blocking OpenMP 4.0 CPU backend..." << std::endl;
+  alpaka_omp4_async::analyze(input, *output, totaltime);
+  std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
+            << std::endl;
+#endif  // ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+
 #ifdef ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking GPU CUDA backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking CUDA GPU backend..." << std::endl;
   alpaka_cuda_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;

--- a/main_cupla.cc
+++ b/main_cupla.cc
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_SYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the blocking CPU serial backend..." << std::endl;
+  std::cout << "\nRunning with the blocking serial CPU backend..." << std::endl;
   cupla_seq_seq_sync::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking CPU serial backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking serial CPU backend..." << std::endl;
   cupla_seq_seq_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking CPU TBB parallel backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking TBB CPU backend..." << std::endl;
   cupla_tbb_seq_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
@@ -39,15 +39,23 @@ int main(int argc, char** argv) {
 
 #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking CPU OpenMP 2.0 backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking OpenMP 2.0 blocks CPU backend..." << std::endl;
   cupla_omp2_seq_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
 #endif  // ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ASYNC_BACKEND
 
+#ifdef ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+  output = std::make_unique<Output>();
+  std::cout << "\nRunning with the non-blocking OpenMP 4.0 CPU backend..." << std::endl;
+  cupla_omp4_omp4_async::analyze(input, *output, totaltime);
+  std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
+            << std::endl;
+#endif  // ALPAKA_ACC_CPU_BT_OMP4_ASYNC_BACKEND
+
 #ifdef ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND
   output = std::make_unique<Output>();
-  std::cout << "\nRunning with the non-blocking GPU CUDA backend..." << std::endl;
+  std::cout << "\nRunning with the non-blocking CUDA GPU backend..." << std::endl;
   cupla_cuda_async::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;


### PR DESCRIPTION
Other changes
  - move the -pthread flag to the ALPAKA_CXX_FLAGS and ALPAKA_LD_FLAGS
  - fix the "source env.sh" message
  - build the test-cupla binary even if there is no CUDA support