### PR TITLE
Rework the implementation for the SYCL backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TBB_BASE    :=
 CUDA_BASE   := /usr/local/cuda
 ALPAKA_BASE := /usr/local/alpaka/alpaka
 CUPLA_BASE  := /usr/local/alpaka/cupla
-ONEAPI_BASE := /opt/intel/inteloneapi/compiler/latest/linux
+ONEAPI_BASE := /opt/sycl/latest
 DPCT_BASE   := /opt/intel/inteloneapi/dpcpp-ct/latest
 
 # host compiler
@@ -651,12 +651,12 @@ endif
 
 ifdef ONEAPI_BASE
 oneapi: test-oneapi test-oneapi-opencl test-oneapi-cuda
-	@echo -e $(GREEN)oneAPI targets built$(RESET)
+	@echo -e $(GREEN)Intel oneAPI targets built$(RESET)
 
 oneapi-debug: debug-oneapi debug-oneapi-opencl debug-oneapi-cuda
-	@echo -e $(GREEN)oneAPI debug targets built$(RESET)
+	@echo -e $(GREEN)Intel oneAPI debug targets built$(RESET)
 
-# oneAPI implementation
+# Intel oneAPI implementation
 test-oneapi-opencl: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
 	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=spir64-*-*-sycldevice $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
@@ -693,9 +693,9 @@ endif
 
 else
 oneapi:
-	@echo -e $(YELLOW)Intel oneAPI not found$(RESET), oneAPI targets will not be built
+	@echo -e $(YELLOW)Intel oneAPI toolchain not found$(RESET), oneAPI targets will not be built
 
 oneapi-debug:
-	@echo -e $(YELLOW)Intel oneAPI not found$(RESET), oneAPI debug targets will not be built
+	@echo -e $(YELLOW)Intel oneAPI toolchain not found$(RESET), oneAPI debug targets will not be built
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,14 @@ endif
 endif
 ifdef ONEAPI_BASE
 ONEAPI_CXX   := $(ONEAPI_BASE)/bin/clang++
-ONEAPI_FLAGS := -fsycl -I$(DPCT_BASE)/include -Wno-unknown-cuda-version
+ONEAPI_FLAGS := -fsycl -I$(DPCT_BASE)/include
+HAVE_LLVM_11 := $(wildcard $(ONEAPI_BASE)/bin/clang-11)
+ifdef HAVE_LLVM_11
+ONEAPI_FLAGS := $(ONEAPI_FLAGS) -Wno-unknown-cuda-version
+endif
 ifdef CUDA_BASE
-ONEAPI_CUDA_PLUGIN := $(wildcard $(ONEAPI_BASE)/lib64/libpi_cuda.so)
-ONEAPI_CUDA_FLAGS  := -fsycl-targets=nvptx64-nvidia-cuda-sycldevice --cuda-path=$(CUDA_BASE)
+ONEAPI_CUDA_PLUGIN := $(wildcard $(ONEAPI_LIBDIR)/libpi_cuda.so)
+ONEAPI_CUDA_FLAGS  := --cuda-path=$(CUDA_BASE)
 endif
 endif
 
@@ -136,6 +140,9 @@ environment: env.sh
 
 env.sh: Makefile
 	@echo '#! /bin/bash' > $@
+ifdef ONEAPI_LIBDIR
+	@echo 'export PATH=$(ONEAPI_BASE)/bin:$$PATH' >> $@
+endif
 	@echo -n 'export LD_LIBRARY_PATH=' >> $@
 ifdef TBB_LIBDIR
 	@echo -n '$(TBB_LIBDIR):' >> $@

--- a/Makefile
+++ b/Makefile
@@ -650,25 +650,31 @@ kokkos-debug:
 endif
 
 ifdef ONEAPI_BASE
-oneapi: test-oneapi test-oneapi-cuda
+oneapi: test-oneapi test-oneapi-opencl test-oneapi-cuda
 	@echo -e $(GREEN)oneAPI targets built$(RESET)
 
-oneapi-debug: debug-oneapi debug-oneapi-cuda
+oneapi-debug: debug-oneapi debug-oneapi-opencl debug-oneapi-cuda
 	@echo -e $(GREEN)oneAPI debug targets built$(RESET)
 
 # oneAPI implementation
-test-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+test-oneapi-opencl: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=spir64-*-*-sycldevice $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
-debug-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+debug-oneapi-opencl: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=spir64-*-*-sycldevice $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 ifdef ONEAPI_CUDA_PLUGIN
 test-oneapi-cuda: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=nvptx64-*-*-sycldevice $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 debug-oneapi-cuda: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
-	$(ONEAPI_CXX) $(ONEAPI_FLAGS) $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=nvptx64-*-*-sycldevice $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+
+test-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=nvptx64-*-*-sycldevice,spir64-*-*-sycldevice $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+
+debug-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=nvptx64-*-*-sycldevice,spir64-*-*-sycldevice $(ONEAPI_CUDA_FLAGS) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 else
 test-oneapi-cuda:
@@ -676,6 +682,12 @@ test-oneapi-cuda:
 
 debug-oneapi-cuda:
 	@echo -e $(YELLOW)NVIDIA CUDA support not found$(RESET), oneAPI debug targets using CUDA will not be built
+
+test-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=spir64-*-*-sycldevice $(CXX_FLAGS) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
+
+debug-oneapi: main_oneapi.cc analyzer_oneapi.cc analyzer_oneapi.h rawtodigi_oneapi.cc rawtodigi_oneapi.h
+	$(ONEAPI_CXX) $(ONEAPI_FLAGS) -fsycl-targets=spir64-*-*-sycldevice $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ONEAPI -o $@ main_oneapi.cc analyzer_oneapi.cc rawtodigi_oneapi.cc
 
 endif
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The test programs are divided in three units
 |                |                       | `test-kokkos-openmp`            | `DIGI_KOKKOS`, `DIGI_KOKKOS_OPENMP`                                                   |
 | Kokkos on GPU  |                       | `test-kokkos-cuda`              | `DIGI_KOKKOS`, `DIGI_KOKKOS_CUDA`                                                     |
 | Intel oneAPI   | `oneapi`              | `test-oneapi`                   | `DIGI_ONEAPI`                                                                         |
+|  - OpenCL      |                       | `test-oneapi-opencl`            | `DIGI_ONEAPI`                                                                         |
+|  - CUDA        |                       | `test-oneapi-cuda`              | `DIGI_ONEAPI`                                                                         |
 
 
 The per-technology targets build all the executables of that
@@ -101,9 +103,21 @@ working directory.
 
 ### Intel oneAPI
 
-The beta version of Intel oneAPI can be obtained from https://software.intel.com/en-us/oneapi .
+The test program relies on the In-Order Queues and Unified Shared Memory extensions
+to SYCL 1.2.1, which are currently available in Intel oneAPI toolchain and in the
+LLVM SYCL branch.
 
-The tests programs choose an OpenCL device at runtime using the `cl::sycl::default_selector`.
+The beta version of Intel oneAPI can be obtained from
+https://software.intel.com/en-us/oneapi .
+
+The in-development version of the LLVM compiler with support for SYCL, Intel's
+extensions, and Codeplay's CUDA backend is available on GitHub at
+https://github.com/intel/llvm/ .
+See [the instructions](https://patatrack.web.cern.ch/patatrack/wiki/SYCL/)
+on the Patatrack Wiki for building the SYCL toolchain.
+
+The test program should run on any available SYCL device, and can select it at
+runtime based on the command line options.
 
 ## How to add a new implementation?
 

--- a/analyzer_oneapi.cc
+++ b/analyzer_oneapi.cc
@@ -41,12 +41,12 @@ namespace oneapi {
       output = Output{};
 
 #if __SYCL_COMPILER_VERSION <= 20200118
-      auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), device, queue.get_context());
+      auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), queue.get_device(), queue.get_context());
 #else
       auto input_d = (Input *)cl::sycl::malloc_device(sizeof(Input), queue);
 #endif
       if (input_d == nullptr) {
-        std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of device memory" << std::endl;
+        std::cerr << "oneAPI runtime failed to allocate " << sizeof(Input) << " bytes of device memory" << std::endl;
         exit(1);
       }
 #if __SYCL_COMPILER_VERSION <= 20200118
@@ -55,18 +55,18 @@ namespace oneapi {
       auto input_h = (Input *)cl::sycl::malloc_host(sizeof(Input), queue);
 #endif
       if (input_h == nullptr) {
-        std::cerr << "oneAPI failed to allocate " << sizeof(Input) << " bytes of host memory" << std::endl;
+        std::cerr << "oneAPI runtime failed to allocate " << sizeof(Input) << " bytes of host memory" << std::endl;
         exit(1);
       }
       std::memcpy(input_h, &input, sizeof(Input));
 
 #if __SYCL_COMPILER_VERSION <= 20200118
-      auto output_d = (Output *)cl::sycl::malloc_device(sizeof(Output), device, queue.get_context());
+      auto output_d = (Output *)cl::sycl::malloc_device(sizeof(Output), queue.get_device(), queue.get_context());
 #else
       auto output_d = (Output *)cl::sycl::malloc_device(sizeof(Output), queue);
 #endif
       if (output_d == nullptr) {
-        std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of device memory" << std::endl;
+        std::cerr << "oneAPI runtime failed to allocate " << sizeof(Output) << " bytes of device memory" << std::endl;
         exit(1);
       }
 #if __SYCL_COMPILER_VERSION <= 20200118
@@ -75,7 +75,7 @@ namespace oneapi {
       auto output_h = (Output *)cl::sycl::malloc_host(sizeof(Output), queue);
 #endif
       if (output_h == nullptr) {
-        std::cerr << "oneAPI failed to allocate " << sizeof(Output) << " bytes of host memory" << std::endl;
+        std::cerr << "oneAPI runtime failed to allocate " << sizeof(Output) << " bytes of host memory" << std::endl;
         exit(1);
       }
       output_h->err.construct(pixelgpudetails::MAX_FED_WORDS, output_d->err_d);

--- a/main_oneapi.cc
+++ b/main_oneapi.cc
@@ -10,12 +10,6 @@
 #include "modules.h"
 #include "output.h"
 
-namespace {
-  constexpr int NLOOPS = 100;
-}
-
-enum class DeviceType { all_devices = -1, default_device = 0, host_device, cpu_device, gpu_device, cuda_device };
-
 class cuda_selector : public cl::sycl::device_selector {
 public:
   int operator()(const cl::sycl::device & device) const override {
@@ -103,7 +97,7 @@ int main(int argc, char **argv) {
               << device.get_info<cl::sycl::info::device::driver_version>() << std::endl;
     oneapi::analyze(device, input, *output, totaltime);
     std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in "
-              << (static_cast<double>(totaltime) / NLOOPS) << " us" << std::endl;
+              << totaltime << " us" << std::endl;
   }
 
   return 0;

--- a/rawtodigi_oneapi.cc
+++ b/rawtodigi_oneapi.cc
@@ -10,16 +10,29 @@
 #include "output.h"
 #include "rawtodigi_oneapi.h"
 
-// experimental printf support
-
+// For host compilation use the standard implementation.
 #ifdef __SYCL_DEVICE_ONLY__
-// according to OpenCL C spec, the printf format string must be in constant address space
+
+#ifdef __SYCL_NVPTX__
+
+// Not yet supported by the CUDA backend
+#define printf(FORMAT, ...)                                               \
+  do {                                                                    \
+  } while (false)
+
+#else
+// Experimental printf support for Intel SYCL/OpenCL backend
+// According to OpenCL C spec, the printf format string must be in constant address space
 #define printf(FORMAT, ...)                                               \
   do {                                                                    \
     static const __attribute__((opencl_constant)) char format[] = FORMAT; \
     cl::sycl::intel::experimental::printf(format, ##__VA_ARGS__);         \
   } while (false)
-#endif
+
+#endif  // __SYCL_NVPTX__
+
+#endif  // __SYCL_DEVICE_ONLY__
+
 
 namespace oneapi {
 


### PR DESCRIPTION
Rename the Intel oneAPI backend to SYCL.
Build a single binary with support for both CUDA and OpenCL backends.
Run on all devices by default, or restrict the choice with command line options.