### PR TITLE
Move the number of loops to a separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ alpaka-debug: debug-alpaka-serial debug-alpaka-tbb debug-alpaka-omp2 debug-alpak
 $(BUILD)/rawtodigi_alpaka.serial.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) -o $@ -c $<
 
-$(BUILD)/analyzer_alpaka.serial.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
+$(BUILD)/analyzer_alpaka.serial.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) -o $@ -c $<
 
 $(BUILD)/main_alpaka.serial.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(BUILD)
@@ -223,7 +223,7 @@ test-alpaka-serial: $(BUILD)/main_alpaka.serial.o $(BUILD)/analyzer_alpaka.seria
 $(DEBUG)/rawtodigi_alpaka.serial.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) -o $@ -c $<
 
-$(DEBUG)/analyzer_alpaka.serial.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
+$(DEBUG)/analyzer_alpaka.serial.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) -o $@ -c $<
 
 $(DEBUG)/main_alpaka.serial.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(DEBUG)
@@ -236,7 +236,7 @@ debug-alpaka-serial: $(DEBUG)/main_alpaka.serial.o $(DEBUG)/analyzer_alpaka.seri
 $(BUILD)/rawtodigi_alpaka.tbb.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(TBB_CXX_FLAGS) -o $@ -c $<
 
-$(BUILD)/analyzer_alpaka.tbb.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
+$(BUILD)/analyzer_alpaka.tbb.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(TBB_CXX_FLAGS) -o $@ -c $<
 
 $(BUILD)/main_alpaka.tbb.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(BUILD)
@@ -248,7 +248,7 @@ test-alpaka-tbb: $(BUILD)/main_alpaka.tbb.o $(BUILD)/analyzer_alpaka.tbb.o $(BUI
 $(DEBUG)/rawtodigi_alpaka.tbb.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(TBB_CXX_FLAGS) -o $@ -c $<
 
-$(DEBUG)/analyzer_alpaka.tbb.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
+$(DEBUG)/analyzer_alpaka.tbb.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(TBB_CXX_FLAGS) -o $@ -c $<
 
 $(DEBUG)/main_alpaka.tbb.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(DEBUG)
@@ -261,7 +261,7 @@ debug-alpaka-tbb: $(DEBUG)/main_alpaka.tbb.o $(DEBUG)/analyzer_alpaka.tbb.o $(DE
 $(BUILD)/rawtodigi_alpaka.omp2.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(OMP_CXX_FLAGS) -o $@ -c $<
 
-$(BUILD)/analyzer_alpaka.omp2.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
+$(BUILD)/analyzer_alpaka.omp2.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(OMP_CXX_FLAGS) -o $@ -c $<
 
 $(BUILD)/main_alpaka.omp2.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(BUILD)
@@ -273,7 +273,7 @@ test-alpaka-omp2: $(BUILD)/main_alpaka.omp2.o $(BUILD)/analyzer_alpaka.omp2.o $(
 $(DEBUG)/rawtodigi_alpaka.omp2.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(OMP_CXX_FLAGS) -o $@ -c $<
 
-$(DEBUG)/analyzer_alpaka.omp2.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
+$(DEBUG)/analyzer_alpaka.omp2.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(OMP_CXX_FLAGS) -o $@ -c $<
 
 $(DEBUG)/main_alpaka.omp2.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(DEBUG)
@@ -286,7 +286,7 @@ debug-alpaka-omp2: $(DEBUG)/main_alpaka.omp2.o $(DEBUG)/analyzer_alpaka.omp2.o $
 $(BUILD)/rawtodigi_alpaka.omp4.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_BT_OMP4_ENABLED $(ALPAKA_CXX_FLAGS) $(OMP_CXX_FLAGS) -o $@ -c $<
 
-$(BUILD)/analyzer_alpaka.omp4.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
+$(BUILD)/analyzer_alpaka.omp4.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_BT_OMP4_ENABLED $(ALPAKA_CXX_FLAGS) $(OMP_CXX_FLAGS) -o $@ -c $<
 
 $(BUILD)/main_alpaka.omp4.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(BUILD)
@@ -298,7 +298,7 @@ test-alpaka-omp4: $(BUILD)/main_alpaka.omp4.o $(BUILD)/analyzer_alpaka.omp4.o $(
 $(DEBUG)/rawtodigi_alpaka.omp4.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_BT_OMP4_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(OMP_CXX_FLAGS) -o $@ -c $<
 
-$(DEBUG)/analyzer_alpaka.omp4.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
+$(DEBUG)/analyzer_alpaka.omp4.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(CXX) $(CXX_FLAGS) $(CXX_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_CPU_BT_OMP4_ENABLED $(ALPAKA_CXX_FLAGS) $(ALPAKA_DEBUG) $(OMP_CXX_FLAGS) -o $@ -c $<
 
 $(DEBUG)/main_alpaka.omp4.o: main_alpaka.cc analyzer_alpaka.h alpakaConfig.h input.h pixelgpudetails.h modules.h output.h GPUSimpleVector.h | $(DEBUG)
@@ -312,7 +312,7 @@ ifdef CUDA_BASE
 $(BUILD)/rawtodigi_alpaka.cuda.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(NVCC) $(NVCC_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_GPU_CUDA_ENABLED $(ALPAKA_NVCC_FLAGS) -o $@ -x cu -dc $<
 
-$(BUILD)/analyzer_alpaka.cuda.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
+$(BUILD)/analyzer_alpaka.cuda.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(BUILD)
 	$(NVCC) $(NVCC_FLAGS) -DDIGI_ALPAKA -DALPAKA_ACC_GPU_CUDA_ENABLED $(ALPAKA_NVCC_FLAGS) -o $@ -x cu -dc $<
 
 $(BUILD)/alpaka.dlink.o: $(BUILD)/rawtodigi_alpaka.cuda.o $(BUILD)/analyzer_alpaka.cuda.o
@@ -327,7 +327,7 @@ test-alpaka-cuda: $(BUILD)/main_alpaka.cuda.o $(BUILD)/analyzer_alpaka.cuda.o $(
 $(DEBUG)/rawtodigi_alpaka.cuda.o: rawtodigi_alpaka.cc GPUSimpleVector.h alpakaConfig.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(NVCC) $(NVCC_FLAGS) $(NVCC_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_GPU_CUDA_ENABLED $(ALPAKA_NVCC_FLAGS) $(ALPAKA_DEBUG) -o $@ -x cu -dc $<
 
-$(DEBUG)/analyzer_alpaka.cuda.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
+$(DEBUG)/analyzer_alpaka.cuda.o: analyzer_alpaka.cc GPUSimpleVector.h alpakaConfig.h analyzer_alpaka.h input.h loops.h output.h pixelgpudetails.h rawtodigi_alpaka.h | $(DEBUG)
 	$(NVCC) $(NVCC_FLAGS) $(NVCC_DEBUG) -DDIGI_ALPAKA -DALPAKA_ACC_GPU_CUDA_ENABLED $(ALPAKA_NVCC_FLAGS) $(ALPAKA_DEBUG) -o $@ -x cu -dc $<
 
 $(DEBUG)/alpaka.dlink.o: $(DEBUG)/rawtodigi_alpaka.cuda.o $(DEBUG)/analyzer_alpaka.cuda.o
@@ -598,7 +598,7 @@ kokkos-debug:
 $(BUILD)/rawtodigi_kokkos.serial.o: rawtodigi_kokkos.cc rawtodigi_kokkos.h pixelgpudetails.h input.h output.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_SERIAL $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
-$(BUILD)/analyzer_kokkos.serial.o: analyzer_kokkos.cc analyzer_kokkos.h input.h output.h rawtodigi_kokkos.h | $(BUILD)
+$(BUILD)/analyzer_kokkos.serial.o: analyzer_kokkos.cc analyzer_kokkos.h input.h loops.h output.h rawtodigi_kokkos.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_SERIAL $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
 $(BUILD)/main_kokkos.serial.o: main_kokkos.cc analyzer_kokkos.h input.h modules.h output.h | $(BUILD)
@@ -612,7 +612,7 @@ test-kokkos-serial: $(BUILD)/main_kokkos.serial.o $(BUILD)/analyzer_kokkos.seria
 $(BUILD)/rawtodigi_kokkos.omp.o: rawtodigi_kokkos.cc rawtodigi_kokkos.h pixelgpudetails.h input.h output.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_OPENMP $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
-$(BUILD)/analyzer_kokkos.omp.o: analyzer_kokkos.cc analyzer_kokkos.h input.h output.h rawtodigi_kokkos.h | $(BUILD)
+$(BUILD)/analyzer_kokkos.omp.o: analyzer_kokkos.cc analyzer_kokkos.h input.h loops.h output.h rawtodigi_kokkos.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_OPENMP $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
 $(BUILD)/main_kokkos.omp.o: main_kokkos.cc analyzer_kokkos.h input.h modules.h output.h | $(BUILD)
@@ -625,7 +625,7 @@ test-kokkos-openmp:  $(BUILD)/main_kokkos.omp.o $(BUILD)/analyzer_kokkos.omp.o $
 $(BUILD)/rawtodigi_kokkos.cuda.o: rawtodigi_kokkos.cc rawtodigi_kokkos.h pixelgpudetails.h input.h output.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_SERIAL $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
-$(BUILD)/analyzer_kokkos.cuda.o: analyzer_kokkos.cc analyzer_kokkos.h input.h output.h rawtodigi_kokkos.h | $(BUILD)
+$(BUILD)/analyzer_kokkos.cuda.o: analyzer_kokkos.cc analyzer_kokkos.h input.h loops.h output.h rawtodigi_kokkos.h | $(BUILD)
 	$(CXX) $(CXX_FLAGS) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) -DDIGI_KOKKOS -DDIGI_KOKKOS_SERIAL $(KOKKOS_CXXLDFLAGS) $(KOKKOS_LIBS) -o $@ -c $<
 
 $(BUILD)/main_kokkos.cuda.o: main_kokkos.cc analyzer_kokkos.h input.h modules.h output.h | $(BUILD)

--- a/analyzer_alpaka.cc
+++ b/analyzer_alpaka.cc
@@ -4,13 +4,10 @@
 #include "alpakaConfig.h"
 #include "analyzer_alpaka.h"
 #include "input.h"
+#include "loops.h"
 #include "output.h"
 #include "pixelgpudetails.h"
 #include "rawtodigi_alpaka.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 

--- a/analyzer_cuda.cc
+++ b/analyzer_cuda.cc
@@ -8,13 +8,10 @@
 #include "cute/check.h"
 #include "cute/launch.h"
 #include "input.h"
+#include "loops.h"
 #include "modules.h"
 #include "output.h"
 #include "rawtodigi_cuda.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 namespace cuda {
 

--- a/analyzer_cupla.cc
+++ b/analyzer_cupla.cc
@@ -12,13 +12,10 @@
 
 #include "cupla_check.h"
 #include "input.h"
+#include "loops.h"
 #include "modules.h"
 #include "output.h"
 #include "rawtodigi_cupla.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 namespace CUPLA_ACCELERATOR_NAMESPACE {
 

--- a/analyzer_kokkos.cc
+++ b/analyzer_kokkos.cc
@@ -2,12 +2,9 @@
 
 #include "analyzer_kokkos.h"
 #include "input.h"
+#include "loops.h"
 #include "output.h"
 #include "rawtodigi_kokkos.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 #ifdef DIGI_KOKKOS_SERIAL
 using KokkosExecSpace = Kokkos::Serial;

--- a/analyzer_naive.cc
+++ b/analyzer_naive.cc
@@ -2,12 +2,9 @@
 #include <memory>
 
 #include "input.h"
+#include "loops.h"
 #include "output.h"
 #include "rawtodigi_naive.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 namespace naive {
   void analyze(Input const& input, std::unique_ptr<Output>& output, double& totaltime) {

--- a/analyzer_oneapi.cc
+++ b/analyzer_oneapi.cc
@@ -6,13 +6,10 @@
 #include <CL/sycl.hpp>
 
 #include "input.h"
+#include "loops.h"
 #include "modules.h"
 #include "output.h"
 #include "rawtodigi_oneapi.h"
-
-namespace {
-  constexpr int NLOOPS = 100;
-}
 
 namespace oneapi {
 

--- a/loops.h
+++ b/loops.h
@@ -1,0 +1,6 @@
+#ifndef loops_h_
+#define loops_h_
+
+constexpr int NLOOPS = 100;
+
+#endif  // loops_h_


### PR DESCRIPTION
Move the definition of the number of loops to a separate file, to simplify making consistent changes to it for all back ends