### PR TITLE
Add test program with run-time backend decision with Kokkos

### DIFF
--- a/analyzer_kokkos.cc
+++ b/analyzer_kokkos.cc
@@ -2,21 +2,12 @@
 
 #include "analyzer_kokkos.h"
 #include "input.h"
+#include "kokkosConfig.h"
 #include "loops.h"
 #include "output.h"
 #include "rawtodigi_kokkos.h"
 
-#ifdef DIGI_KOKKOS_SERIAL
-using KokkosExecSpace = Kokkos::Serial;
-#elif defined DIGI_KOKKOS_OPENMP
-using KokkosExecSpace = Kokkos::OpenMP;
-#elif defined DIGI_KOKKOS_CUDA
-using KokkosExecSpace = Kokkos::Cuda;
-#endif
-
-namespace kokkos {
-  void initialize(int& argc, char** argv) { Kokkos::initialize(argc, argv); }
-
+namespace KOKKOS_NAMESPACE {
   void analyze(Input const& input, Output& output, double& totaltime) {
     totaltime = 0.;
 
@@ -42,7 +33,7 @@ namespace kokkos {
 
       Kokkos::parallel_for(
           Kokkos::RangePolicy<KokkosExecSpace>(0, input.wordCounter), KOKKOS_LAMBDA(const size_t i) {
-            kokkos::rawtodigi(input_d.data(), output_d.data(), wordCounter, true, true, false, i);
+            rawtodigi(input_d.data(), output_d.data(), wordCounter, true, true, false, i);
           });
       Kokkos::fence();  // I don't know if parallel_for is synchronous or not
       Kokkos::deep_copy(output_h, output_d);
@@ -63,6 +54,4 @@ namespace kokkos {
 
     totaltime /= NLOOPS;
   }
-
-  void finalize() { Kokkos::finalize(); }
 }  // namespace kokkos

--- a/analyzer_kokkos.h
+++ b/analyzer_kokkos.h
@@ -4,10 +4,14 @@
 class Input;
 class Output;
 
-namespace kokkos {
-  void initialize(int& argc, char** argv);
+namespace kokkos_serial {
   void analyze(Input const& input, Output& output, double& totaltime);
-  void finalize();
+}  // namespace kokkos
+namespace kokkos_openmp {
+  void analyze(Input const& input, Output& output, double& totaltime);
+}  // namespace kokkos
+namespace kokkos_cuda {
+  void analyze(Input const& input, Output& output, double& totaltime);
 }  // namespace kokkos
 
 #endif

--- a/kokkosConfig.h
+++ b/kokkosConfig.h
@@ -1,0 +1,22 @@
+#ifndef kokkosConfig_h_
+#define kokkosConfig_h_
+
+#include <Kokkos_Core.hpp>
+
+#ifdef DIGI_KOKKOS_SERIAL
+using KokkosExecSpace = Kokkos::Serial;
+#define KOKKOS_NAMESPACE kokkos_serial
+#elif defined DIGI_KOKKOS_OPENMP
+using KokkosExecSpace = Kokkos::OpenMP;
+#define KOKKOS_NAMESPACE kokkos_openmp
+#elif defined DIGI_KOKKOS_CUDA
+using KokkosExecSpace = Kokkos::Cuda;
+#define KOKKOS_NAMESPACE kokkos_cuda
+#endif
+
+namespace kokkos_common {
+  void initialize(const Kokkos::InitArguments& arguments);
+  void finalize();
+}
+
+#endif

--- a/kokkosConfig_common.cc
+++ b/kokkosConfig_common.cc
@@ -1,0 +1,11 @@
+#include "kokkosConfig.h"
+
+namespace kokkos_common {
+  void initialize(const Kokkos::InitArguments& arguments) {
+    Kokkos::initialize(arguments);
+  }
+
+  void finalize() {
+    Kokkos::finalize();
+  }
+}

--- a/main_kokkos.cc
+++ b/main_kokkos.cc
@@ -5,11 +5,40 @@
 
 #include "analyzer_kokkos.h"
 #include "input.h"
+#include "kokkosConfig.h"
 #include "modules.h"
 #include "output.h"
 
+namespace {
+  void print_help(std::string const& name) {
+    std::cout
+        << name << ": [--numberOfThreads NT]"
+        << "\n\n"
+        << "Options\n"
+        << " --numberOfThreads   Number of threads to use (default -1 for all cores(?)1)\n"
+        << std::endl;
+  }
+}  // namespace
+
 int main(int argc, char **argv) {
-  kokkos::initialize(argc, argv);
+  std::vector<std::string> args(argv, argv + argc);
+  int numberOfThreads = -1;
+  for (auto i = args.begin() + 1, e = args.end(); i != e; ++i) {
+    if (*i == "-h" or *i == "--help") {
+      print_help(args.front());
+      return EXIT_SUCCESS;
+    } else if (*i == "--numberOfThreads") {
+      ++i;
+      numberOfThreads = std::stoi(*i);
+    }
+  }
+
+  {
+    Kokkos::InitArguments arguments;
+    arguments.num_threads = numberOfThreads;
+    kokkos_common::initialize(arguments);
+  }
+ 
 
   Input input = read_input();
   std::cout << "Got " << input.cablingMap.size << " for cabling, wordCounter " << input.wordCounter << std::endl;
@@ -17,13 +46,34 @@ int main(int argc, char **argv) {
   std::unique_ptr<Output> output;
   double totaltime = 0;
 
+#ifdef DIGI_KOKKOS_SERIAL
+  totaltime = 0;
   output = std::make_unique<Output>();
-  //std::cout << "\nRunning with the serial CPU backend..." << std::endl;
-  kokkos::analyze(input, *output, totaltime);
+  std::cout << "\nRunning with the serial CPU backend..." << std::endl;
+  kokkos_serial::analyze(input, *output, totaltime);
   std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
             << std::endl;
+#endif
 
-  kokkos::finalize();
+#ifdef DIGI_KOKKOS_OPENMP
+  totaltime = 0;
+  output = std::make_unique<Output>();
+  std::cout << "\nRunning with the OpenMP backend..." << std::endl;
+  kokkos_openmp::analyze(input, *output, totaltime);
+  std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
+            << std::endl;
+#endif
+
+#ifdef DIGI_KOKKOS_CUDA
+  totaltime = 0;
+  output = std::make_unique<Output>();
+  std::cout << "\nRunning with the CUDA backend..." << std::endl;
+  kokkos_cuda::analyze(input, *output, totaltime);
+  std::cout << "Output: " << countModules(output->moduleInd, input.wordCounter) << " modules in " << totaltime << " us"
+            << std::endl;
+#endif
+
+  kokkos_common::finalize();
 
   return 0;
 }

--- a/rawtodigi_kokkos.cc
+++ b/rawtodigi_kokkos.cc
@@ -3,11 +3,12 @@
 #include <Kokkos_Core.hpp>
 
 #include "input.h"
+#include "kokkosConfig.h"
 #include "output.h"
 #include "pixelgpudetails.h"
 #include "rawtodigi_kokkos.h"
 
-namespace kokkos {
+namespace KOKKOS_NAMESPACE {
   class Packing {
   public:
     using PackedDigiType = uint32_t;

--- a/rawtodigi_kokkos.h
+++ b/rawtodigi_kokkos.h
@@ -3,10 +3,12 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include "kokkosConfig.h"
+
 class Input;
 class Output;
 
-namespace kokkos {
+namespace KOKKOS_NAMESPACE {
   KOKKOS_FUNCTION void rawtodigi(const Input* input,
                                  Output* output,
                                  const uint32_t wordCounter,


### PR DESCRIPTION
With Kokkos 3.0.00 must have configure-time choice whether the CUDA backend is included or not.